### PR TITLE
Escalate privileges

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
 #Configure resolv.conf
 - name: Configure resolv.conf
-  template: src=resolv.conf.j2 dest=/etc/resolv.conf
+  template:
+    src: resolv.conf.j2
+    dest: /etc/resolv.conf
+  become: yes


### PR DESCRIPTION
without adding `become: yes` on a task/step-level we are assuming that the whole role is run as root - which should not be done and is also not needed.
