### PR TITLE
Set permissions of resolv.conf explicitly

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
-#Configure resolv.conf
+# Configure resolv.conf
 - name: Configure resolv.conf
-  template: src=resolv.conf.j2 dest=/etc/resolv.conf
+  template:
+    src: resolv.conf.j2
+    dest: /etc/resolv.conf
+    mode: 0644


### PR DESCRIPTION
In some cases the file ends up with a mode of 0770, which prevents non-root
users from performing name lookups. I don't think this role is necessarily
at fault in those cases, but it doesn't hurt to set the permissions explicitly.