### PR TITLE
Prevent wiping existing resolv.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ An Ansible role to configure /etc/resolv.conf
             - "timeout:2"
             - "rotate"
 ```
+### Role Invocation with externaly defined variables (group_vars / host_vars)
+```yaml
+    - name: "Role Invocation - ahuffman.resolv Example"
+      hosts: "all"
+      roles:
+        - role: "ahuffman.resolv"
+          when:
+            - resolv_nameservers is defined
+            - resolv_nameservers | length > 0
+```
 ### Included Role
 ```yaml
 ---

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
-resolv_nameservers: []
-resolv_domain: ""
-resolv_search: []
-resolv_sortlist: []
-resolv_options: []
+# resolv_nameservers: []
+# resolv_domain: ""
+# resolv_search: []
+# resolv_sortlist: []
+# resolv_options: []
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,4 +4,4 @@
     src: "resolv.conf.j2"
     dest: "/etc/resolv.conf"
     mode: "0644"
-  become: True
+  become: true

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,19 +1,19 @@
-# {{ ansible_managed }}
+# {{ ansible_managed }}. role: resolv, template: resolv.conf.j2
 
-{% if resolv_search | length > 0 %}
+{% if resolv_search is defined and resolv_search | length > 0 %}
 search {{ resolv_search|join(' ') }}
 {% endif %}
-{% if resolv_domain != "" %}
+{% if resolv_domain is defined and resolv_domain != "" %}
 domain {{ resolv_domain }}
 {% endif %}
 {% for ns in resolv_nameservers %}
 nameserver {{ ns }}
 {% endfor %}
-{% if resolv_sortlist | length > 0 %}
+{% if resolv_sortlist is defined and resolv_sortlist | length > 0 %}
 {% for sl in resolv_sortlist %}
 sortlist {{ sl }}
 {% endfor %}
 {% endif %}
-{% if resolv_options | length > 0 %}
+{% if resolv_options is defined and resolv_options | length > 0 %}
 options {{ resolv_options|join(' ') }}
 {% endif %}

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}. role: resolv, template: resolv.conf.j2
+# {{ ansible_managed }}
 
 {% if resolv_search is defined and resolv_search | length > 0 %}
 search {{ resolv_search|join(' ') }}


### PR DESCRIPTION
Prevent wiping existing resolv.conf with emptyness when no variables are defined or defined but empty.